### PR TITLE
ENH Add "PHP 8.5 support" to the roadmap for CMS 6.2

### DIFF
--- a/data.json
+++ b/data.json
@@ -103,6 +103,10 @@
                 {
                     "title": "In-CMS accessibility improvements",
                     "description": "Determine and deliver a valuable set of accessibility improvements to the CMS itself."
+                },
+                {
+                    "title": "PHP 8.5 support",
+                    "description": "Add support for PHP 8.5 across all supported modules."
                 }
             ]
         },


### PR DESCRIPTION
Will look like this

<img width="1423" height="986" alt="image" src="https://github.com/user-attachments/assets/a83ba66b-80c7-4740-a8f0-7e32fa2d2c1c" />


## Issue

- https://github.com/silverstripe/roadmap/issues/3